### PR TITLE
ci: workaround -autofree codegen bug with nested fn calls on macos

### DIFF
--- a/tutorials/building_a_simple_web_blog_with_vweb/code/blog/blog.v
+++ b/tutorials/building_a_simple_web_blog_with_vweb/code/blog/blog.v
@@ -74,7 +74,8 @@ pub fn (mut app App) new_article() vweb.Result {
 ['/articles'; get]
 pub fn (mut app App) articles() vweb.Result {
 	articles := app.find_all_articles()
-	return app.json(json.encode(articles))
+	json_result := json.encode(articles)
+	return app.json(json_result)
 }
 
 fn (mut app App) time() {


### PR DESCRIPTION

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please run `v test-all` .
See also `TESTS.md`.

I try to process PRs as soon as possible. They should be handled within 24 hours.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
